### PR TITLE
add welcome view

### DIFF
--- a/FlashSpeak/FlashSpeak.xcodeproj/project.pbxproj
+++ b/FlashSpeak/FlashSpeak.xcodeproj/project.pbxproj
@@ -16,6 +16,12 @@
 		8611FA1C29ED94220076B73B /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8611FA1B29ED94220076B73B /* URLSession.swift */; };
 		8691656629E9B7F7003816DB /* UrlConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8691656529E9B7F7003816DB /* UrlConfiguration.swift */; };
 		95151B8629FAA1AC00096A7B /* Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B8529FAA1AC00096A7B /* Layout.swift */; };
+		95151B8D29FB80AC00096A7B /* WelcomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B8C29FB80AC00096A7B /* WelcomeViewController.swift */; };
+		95151B8F29FB80B500096A7B /* WelcomePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B8E29FB80B500096A7B /* WelcomePresenter.swift */; };
+		95151B9129FB80BD00096A7B /* WelcomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B9029FB80BD00096A7B /* WelcomeRouter.swift */; };
+		95151B9329FB80C500096A7B /* WelcomeBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B9229FB80C500096A7B /* WelcomeBuilder.swift */; };
+		95151B9529FB80D800096A7B /* WelcomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B9429FB80D800096A7B /* WelcomeCoordinator.swift */; };
+		95151B9729FB884C00096A7B /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95151B9629FB884C00096A7B /* WelcomeView.swift */; };
 		95399EDE29F85897003E6DC8 /* ListsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95399EDD29F85897003E6DC8 /* ListsRouter.swift */; };
 		95399EE229F8F19A003E6DC8 /* ListCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95399EE129F8F19A003E6DC8 /* ListCellModel.swift */; };
 		95399EE529F903BD003E6DC8 /* WordCardsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95399EE429F903BD003E6DC8 /* WordCardsRouter.swift */; };
@@ -146,6 +152,12 @@
 		8691656529E9B7F7003816DB /* UrlConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlConfiguration.swift; sourceTree = "<group>"; };
 		8691656A29E9CE62003816DB /* FlashSpeak.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FlashSpeak.entitlements; sourceTree = "<group>"; };
 		95151B8529FAA1AC00096A7B /* Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Layout.swift; sourceTree = "<group>"; };
+		95151B8C29FB80AC00096A7B /* WelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeViewController.swift; sourceTree = "<group>"; };
+		95151B8E29FB80B500096A7B /* WelcomePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomePresenter.swift; sourceTree = "<group>"; };
+		95151B9029FB80BD00096A7B /* WelcomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeRouter.swift; sourceTree = "<group>"; };
+		95151B9229FB80C500096A7B /* WelcomeBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeBuilder.swift; sourceTree = "<group>"; };
+		95151B9429FB80D800096A7B /* WelcomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeCoordinator.swift; sourceTree = "<group>"; };
+		95151B9629FB884C00096A7B /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		95399EDD29F85897003E6DC8 /* ListsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListsRouter.swift; sourceTree = "<group>"; };
 		95399EE129F8F19A003E6DC8 /* ListCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCellModel.swift; sourceTree = "<group>"; };
 		95399EE429F903BD003E6DC8 /* WordCardsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordCardsRouter.swift; sourceTree = "<group>"; };
@@ -312,6 +324,51 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		95151B8729FB806200096A7B /* Welcome */ = {
+			isa = PBXGroup;
+			children = (
+				95151B9429FB80D800096A7B /* WelcomeCoordinator.swift */,
+				95151B8829FB806E00096A7B /* Builder */,
+				95151B8A29FB807B00096A7B /* Presenter */,
+				95151B8B29FB808300096A7B /* Router */,
+				95151B8929FB807600096A7B /* View */,
+			);
+			path = Welcome;
+			sourceTree = "<group>";
+		};
+		95151B8829FB806E00096A7B /* Builder */ = {
+			isa = PBXGroup;
+			children = (
+				95151B9229FB80C500096A7B /* WelcomeBuilder.swift */,
+			);
+			path = Builder;
+			sourceTree = "<group>";
+		};
+		95151B8929FB807600096A7B /* View */ = {
+			isa = PBXGroup;
+			children = (
+				95151B8C29FB80AC00096A7B /* WelcomeViewController.swift */,
+				95151B9629FB884C00096A7B /* WelcomeView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		95151B8A29FB807B00096A7B /* Presenter */ = {
+			isa = PBXGroup;
+			children = (
+				95151B8E29FB80B500096A7B /* WelcomePresenter.swift */,
+			);
+			path = Presenter;
+			sourceTree = "<group>";
+		};
+		95151B8B29FB808300096A7B /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				95151B9029FB80BD00096A7B /* WelcomeRouter.swift */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
 		95399EDF29F8589B003E6DC8 /* Router */ = {
 			isa = PBXGroup;
 			children = (
@@ -417,6 +474,7 @@
 		95689A8029EF168000482CBD /* Flow */ = {
 			isa = PBXGroup;
 			children = (
+				95151B8729FB806200096A7B /* Welcome */,
 				95689A8129EF168C00482CBD /* Lists */,
 				95689A8229EF169000482CBD /* Study */,
 				95689A8329EF169400482CBD /* Statistic */,
@@ -1045,6 +1103,8 @@
 				95689A7529ED84F900482CBD /* NewListView.swift in Sources */,
 				9571A0D429F16DB5007DADFD /* NewListColorCollectionDataSource.swift in Sources */,
 				95689A5729EBDA1400482CBD /* Study.swift in Sources */,
+				95151B8F29FB80B500096A7B /* WelcomePresenter.swift in Sources */,
+				95151B9729FB884C00096A7B /* WelcomeView.swift in Sources */,
 				95437AFC29E8647500C1C295 /* CAGradientLayerExtension.swift in Sources */,
 				9571A0D229F1556B007DADFD /* NewListColorCollectionDelegate.swift in Sources */,
 				95437B0029E8735D00C1C295 /* Language.swift in Sources */,
@@ -1077,6 +1137,7 @@
 				95689A9429F1016E00482CBD /* FakeLists.swift in Sources */,
 				9571A0E229F18674007DADFD /* TabBarCoordinator.swift in Sources */,
 				95B7A82129E6B4CE00751B89 /* StatisticsViewController.swift in Sources */,
+				95151B9129FB80BD00096A7B /* WelcomeRouter.swift in Sources */,
 				9571A0D029F15185007DADFD /* NewListPresenter.swift in Sources */,
 				95437AF629E735C000C1C295 /* ListsView.swift in Sources */,
 				95399EE229F8F19A003E6DC8 /* ListCellModel.swift in Sources */,
@@ -1086,6 +1147,7 @@
 				95689A6B29ED201B00482CBD /* UIFontExtension.swift in Sources */,
 				9571A0CC29F15169007DADFD /* NewListBuilder.swift in Sources */,
 				9571A0C929F14760007DADFD /* LanguageTableDelegate.swift in Sources */,
+				95151B9329FB80C500096A7B /* WelcomeBuilder.swift in Sources */,
 				95689A7F29EF13D400482CBD /* Constants.swift in Sources */,
 				95B7A81D29E6B4C900751B89 /* ListsViewController.swift in Sources */,
 				9571A0BF29F140DC007DADFD /* WordCardsCollectionDataSource.swift in Sources */,
@@ -1121,11 +1183,13 @@
 				8611FA1329ED630B0076B73B /* TranslatedWordsModel.swift in Sources */,
 				95689A5529EBD98C00482CBD /* Word.swift in Sources */,
 				95399EF729FA2DE2003E6DC8 /* StudyRouter.swift in Sources */,
+				95151B9529FB80D800096A7B /* WelcomeCoordinator.swift in Sources */,
 				9571A0DC29F17C04007DADFD /* LanguageGestureRecognizerDelegate.swift in Sources */,
 				9571A0DA29F17B1C007DADFD /* NewLisTextFieldDelegate.swift in Sources */,
 				9571A0AD29F10CDD007DADFD /* StudyCD+CoreDataProperties.swift in Sources */,
 				95DBAAE929F658AD002664FC /* ListMakerCollectionViewDataSource.swift in Sources */,
 				95689A7D29EDC25900482CBD /* LanguageController.swift in Sources */,
+				95151B8D29FB80AC00096A7B /* WelcomeViewController.swift in Sources */,
 				B257FCA629EC174600B542DB /* WordCD+CoreDataClass.swift in Sources */,
 				9571A0D829F17A70007DADFD /* NewListGestureRecognizerDelegate.swift in Sources */,
 				95B7A7EA29E6B48900751B89 /* SceneDelegate.swift in Sources */,

--- a/FlashSpeak/FlashSpeak/Coordinator/AppCoordinator.swift
+++ b/FlashSpeak/FlashSpeak/Coordinator/AppCoordinator.swift
@@ -6,10 +6,11 @@
 //
 
 import UIKit
+import CoreData
 
 protocol AppCoordinatorProtocol: Coordinator {
     func showMainFlow()
-    func showLoginFlow()
+    func showWelcomeFlow()
 }
 
 class AppCoordinator: AppCoordinatorProtocol {
@@ -28,7 +29,14 @@ class AppCoordinator: AppCoordinatorProtocol {
     }
     
     func start() {
-        showMainFlow()
+        if
+            UserDefaultsHelper.nativeLanguage.isEmpty,
+            UserDefaultsHelper.targetLanguage.isEmpty
+        {
+            showWelcomeFlow()
+        } else {
+            showMainFlow()
+        }
     }
     
     func showMainFlow() {
@@ -38,8 +46,11 @@ class AppCoordinator: AppCoordinatorProtocol {
         childCoordinators.append(tabCoordinator)
     }
     
-    func showLoginFlow() {
-        print(#function)
+    func showWelcomeFlow() {
+        let welcomeCoordinator = WelcomeCoordinator(navigationController)
+        welcomeCoordinator.finishDelegate = self
+        welcomeCoordinator.start()
+        childCoordinators.append(welcomeCoordinator)
     }
 }
 
@@ -50,8 +61,8 @@ extension AppCoordinator: CoordinatorFinishDelegate {
         switch childCoordinator.type {
         case .tab:
             navigationController.viewControllers.removeAll()
-            showLoginFlow()
-        case .login:
+            showWelcomeFlow()
+        case .welcome:
             navigationController.viewControllers.removeAll()
             showMainFlow()
         default:

--- a/FlashSpeak/FlashSpeak/Coordinator/Coordinator.swift
+++ b/FlashSpeak/FlashSpeak/Coordinator/Coordinator.swift
@@ -42,5 +42,5 @@ protocol CoordinatorFinishDelegate: AnyObject {
 // MARK: - CoordinatorType
 /// Используя эту структуру, мы можем определить, какой тип потока мы можем использовать в приложении
 enum CoordinatorType {
-    case app, tab, login, lists
+    case app, tab, welcome, lists
 }

--- a/FlashSpeak/FlashSpeak/Core/CoreData/CoreDataManager.swift
+++ b/FlashSpeak/FlashSpeak/Core/CoreData/CoreDataManager.swift
@@ -119,6 +119,21 @@ extension CoreDataManager {
         }
         return listResult
     }
+    
+    func getStudyObject(source: Language, target: Language) -> StudyCD? {
+        guard
+            let studies = self.studies,
+            !studies.isEmpty,
+            let study = studies.first(where: { studyCD in
+                guard
+                    studyCD.sourceLanguage == source.rawValue,
+                    studyCD.targetLanguage == target.rawValue
+                else { return false }
+                return true
+            })
+        else { return nil }
+        return study
+    }
 }
 
 // MARK: - Private

--- a/FlashSpeak/FlashSpeak/Core/UserDefaults/UserDefaultHelper.swift
+++ b/FlashSpeak/FlashSpeak/Core/UserDefaults/UserDefaultHelper.swift
@@ -9,6 +9,8 @@ import Foundation
 
 private enum UserDefaultsKeys: String {
     case nativeLanguage = "nativeLanguageKey"
+    case targetLenguage = "targetLanguageKey"
+    
     case learnQuestionSetting
     case learnAnswerSetting
     case learnLanguageSetting
@@ -27,6 +29,22 @@ struct UserDefaultsHelper {
             .object(forKey: UserDefaultsKeys.nativeLanguage.asString) as? String ?? "" }
         set { UserDefaults.standard
             .set(newValue, forKey: UserDefaultsKeys.nativeLanguage.asString) }
+    }
+    
+    static func source() -> Language? {
+        Language.language(by: self.nativeLanguage)
+    }
+    
+    static var targetLanguage: String {
+        get { UserDefaults.standard
+            .object(forKey: UserDefaultsKeys.targetLenguage.asString) as? String ?? "" }
+        set { UserDefaults.standard
+            .set(newValue, forKey: UserDefaultsKeys.targetLenguage.asString)
+        }
+    }
+    
+    static func target() -> Language? {
+        Language.language(by: self.targetLanguage)
     }
     
     static var learnQuestionSetting: Int {

--- a/FlashSpeak/FlashSpeak/Flow/Lists/ChangeLanguage/Builder/LanguageBuilder.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/ChangeLanguage/Builder/LanguageBuilder.swift
@@ -9,8 +9,8 @@ import UIKit
 
 struct LanguageBuilder {
     
-    static func build(router: LanguageEvent) -> (UIViewController & LanguageViewInput) {
-        let presenter = LanguagePresenter(router: router)
+    static func build(router: LanguageEvent, language: Language) -> (UIViewController & LanguageViewInput) {
+        let presenter = LanguagePresenter(router: router, language: language)
         let tableDataSource = LanguageTableDataSource()
         let tableDelegate = LanguageTableDelegate()
         let gestureRecognizerDelegate = LanguageGestureRecognizerDelegate()

--- a/FlashSpeak/FlashSpeak/Flow/Lists/ChangeLanguage/Presenter/LanguagePresenter.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/ChangeLanguage/Presenter/LanguagePresenter.swift
@@ -18,36 +18,30 @@ protocol LanguageViewInput {
 
 protocol LanguageViewOutput {
     var router: LanguageEvent? { get }
-    var study: Study? { get set }
+    var language: Language? { get set }
     
     func viewDidSelectedLanguage(language: Language)
     func viewDidTapBackground()
-    func viewGetStudy()
     func subscribe()
 }
 
 class LanguagePresenter: ObservableObject {
     
-    @Published var study: Study?
+    @Published var language: Language?
     var router: LanguageEvent?
     weak var viewInput: (UIViewController & LanguageViewInput)?
     
     private var store = Set<AnyCancellable>()
     
-    init(router: LanguageEvent) {
+    init(router: LanguageEvent, language: Language) {
         self.router = router
-        getStudy()
+        self.language = language
     }
     
-    private func getStudy() {
-        // Get study from core data if exist
-        // or create study with local user lang and save to core data
-        
+    private func getLocalLanguage() {
         let localLanguageCode = Locale.current.language.languageCode?.identifier ?? "ru"
         let sourceLanguage = Language.language(by: localLanguageCode) ?? .russian
-        let targetLanguage: Language = .english == sourceLanguage ? .russian : .english
-        
-        study = Study(sourceLanguage: sourceLanguage, targerLanguage: targetLanguage)
+        language = sourceLanguage
     }
     
     private func changeStudy(to language: Language) {
@@ -61,16 +55,12 @@ class LanguagePresenter: ObservableObject {
 extension LanguagePresenter: LanguageViewOutput {
     
     func subscribe() {
-        self.$study
+        self.$language
             .receive(on: RunLoop.main)
-            .sink { study in
-                self.viewInput?.language = study?.targetLanguage
+            .sink { language in
+                self.viewInput?.language = language
             }
             .store(in: &store)
-    }
-    
-    func viewGetStudy() {
-        getStudy()
     }
     
     func viewDidTapBackground() {

--- a/FlashSpeak/FlashSpeak/Flow/Lists/ChangeLanguage/View/LanguageController.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/ChangeLanguage/View/LanguageController.swift
@@ -57,7 +57,6 @@ class LanguageController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         presenter.subscribe()
-        presenter.viewGetStudy()
         configureTableView()
         configureGesture()
     }

--- a/FlashSpeak/FlashSpeak/Flow/Lists/Lists/Router/ListsRouter.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/Lists/Router/ListsRouter.swift
@@ -14,7 +14,7 @@ protocol ListsEvent {
 class ListsRouter: ListsEvent {
     
     enum Event {
-        case newList, changeLanguage, lookList(list: List)
+        case newList, changeLanguage(language: Language), lookList(list: List)
     }
     
     var didSendEventClosure: ((ListsRouter.Event) -> Void)?

--- a/FlashSpeak/FlashSpeak/Flow/Lists/Lists/View/ListsView.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/Lists/View/ListsView.swift
@@ -47,13 +47,19 @@ class ListsView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Functions
+    
+    func configureChangeButton(language: Language) {
+        changeLanguageButton.setImage(UIImage(named: language.code), for: .normal)
+    }
+    
     
     // MARK: - UI
     
     private func configureUI() {
         self.backgroundColor = .backgroundWhite
         addSubviews()
-        configureChangeButton(language: Language.english)
+        configureButtons()
         setupConstraints()
     }
     
@@ -61,6 +67,10 @@ class ListsView: UIView {
         self.addSubview(collectionView)
         self.addSubview(changeLanguageButton)
         self.addSubview(newListButton)
+    }
+    
+    private func configureButtons() {
+        changeLanguageButton.translatesAutoresizingMaskIntoConstraints = false
     }
 
     // swiftlint:disable line_length
@@ -84,10 +94,5 @@ class ListsView: UIView {
     }
     
     // swiftlint:enable line_length
-    
-    private func configureChangeButton(language: Language) {
-        changeLanguageButton.translatesAutoresizingMaskIntoConstraints = false
-        changeLanguageButton.setImage(UIImage(named: language.code), for: .normal)
-    }
     
 }

--- a/FlashSpeak/FlashSpeak/Flow/Lists/Lists/View/ListsViewController.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/Lists/View/ListsViewController.swift
@@ -77,7 +77,7 @@ class ListsViewController: UIViewController {
         listsView.collectionView.dataSource = listsCollectionDataSource
         listsView.collectionView.register(ListCell.self, forCellWithReuseIdentifier: ListCell.identifier)
         
-        presenter.getLists()
+        presenter.getStudyLists()
     }
     
     // MARK: - Actions
@@ -110,6 +110,10 @@ extension ListsViewController: ListsViewInput {
     
     func reloadListsView() {
         listsView.collectionView.reloadData()
+    }
+    
+    func configureLanguageButton(language: Language) {
+        listsView.configureChangeButton(language: language)
     }
 }
 

--- a/FlashSpeak/FlashSpeak/Flow/Lists/ListsCoordinator.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Lists/ListsCoordinator.swift
@@ -11,7 +11,7 @@ protocol ListsCoordinatorProtocol: Coordinator {
     func showListViewController()
     func showNewList()
     func showListMaker(list: List)
-    func showChangeLanguage()
+    func showChangeLanguage(language: Language)
     func showWordCard(list: List)
 }
 
@@ -41,8 +41,8 @@ extension ListsCoordinator: ListsCoordinatorProtocol {
             switch event {
             case .newList:
                 self?.showNewList()
-            case .changeLanguage:
-                self?.showChangeLanguage()
+            case .changeLanguage(let language):
+                self?.showChangeLanguage(language: language)
             case .lookList(let list):
                 self?.showWordCard(list: list)
             }
@@ -82,7 +82,7 @@ extension ListsCoordinator: ListsCoordinatorProtocol {
         self.navigationController.present(newListController, animated: true)
     }
     
-    func showChangeLanguage() {
+    func showChangeLanguage(language: Language) {
         var router = LanguageRouter()
         router.didSendEventClosure = { [weak self] event in
             switch event {
@@ -94,7 +94,7 @@ extension ListsCoordinator: ListsCoordinatorProtocol {
                 self?.navigationController.dismiss(animated: true)
             }
         }
-        let languageController = LanguageBuilder.build(router: router)
+        let languageController = LanguageBuilder.build(router: router, language: language)
         languageController.modalPresentationStyle = .overFullScreen
         self.navigationController.present(languageController, animated: true)
     }

--- a/FlashSpeak/FlashSpeak/Flow/Study/View/View/SettingsButton.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Study/View/View/SettingsButton.swift
@@ -15,26 +15,9 @@ final class SettingsButton: UIButton {
     
     // MARK: - Subviews
     
-    private var questionView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = .white
-        return imageView
-    }()
-    
-    private var answerView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = .white
-        return imageView
-    }()
-    
-    private let languageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = .white
-        return imageView
-    }()
+    private var questionView = UIImageView()
+    private var answerView = UIImageView()
+    private let languageView = UIImageView()
     
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
@@ -82,12 +65,16 @@ final class SettingsButton: UIButton {
     
     private func configure() {
         var configuration = UIButton.Configuration.gray()
-        configuration.baseForegroundColor = .white
         configuration.baseBackgroundColor = .tint
         configuration.cornerStyle = .medium
         configuration.buttonSize = .large
-        
         self.configuration = configuration
+        
+        stackView.arrangedSubviews.forEach { imageView in
+            imageView.contentMode = .scaleAspectFit
+            imageView.tintColor = .white
+        }
+        
         addSubview(stackView)
         configureConstraints()
     }
@@ -107,15 +94,14 @@ extension SettingsButton: SettingableButton {
     // MARK: - Functions
     
     func setSettings(settings: LearnSettings) {
-        print(#function, settings)
         let questionImage: UIImage?
         switch settings.question {
         case .word:
-            questionImage = UIImage(systemName: "a.square.fill")
+            questionImage = UIImage(systemName: "character")
         case .image:
             questionImage = UIImage(systemName: "photo")
         case .wordImage:
-            questionImage = UIImage(systemName: "doc.text.image")
+            questionImage = UIImage(systemName: "doc.richtext.fill")
         }
         questionView.image = questionImage
         

--- a/FlashSpeak/FlashSpeak/Flow/Welcome/Builder/WelcomeBuilder.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Welcome/Builder/WelcomeBuilder.swift
@@ -1,0 +1,17 @@
+//
+//  WelcomeBuilder.swift
+//  FlashSpeak
+//
+//  Created by Denis Dmitriev on 28.04.2023.
+//
+
+import UIKit
+
+struct WelcomeBuilder {
+    static func build(router: WelcomeEvent) -> UIViewController & WelcomeViewInput {
+        let presenter = WelcomePresenter(router: router)
+        let viewController = WelcomeViewController(presenter: presenter)
+        presenter.viewController = viewController
+        return viewController
+    }
+}

--- a/FlashSpeak/FlashSpeak/Flow/Welcome/Presenter/WelcomePresenter.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Welcome/Presenter/WelcomePresenter.swift
@@ -1,0 +1,121 @@
+//
+//  WelcomePresenter.swift
+//  FlashSpeak
+//
+//  Created by Denis Dmitriev on 28.04.2023.
+//
+
+import UIKit
+import Combine
+
+protocol WelcomeViewInput {
+    var presenter: WelcomeViewOutput { get }
+    
+    func didTabDoneButton()
+    func didTabSourceButton()
+    func didTabTargetButton()
+    func configureButtons(type: Language.LanguageType, language: Language)
+    func button(isEnable: Bool)
+}
+
+protocol WelcomeViewOutput {
+    var router: WelcomeEvent? { get }
+    var study: Study { get set }
+    var isReady: Bool { get set }
+    
+    func next()
+    func selectSourceLanguage()
+    func selectTargetLanguage()
+    func subscribe()
+    func setLanguage(type: Language.LanguageType, language: Language)
+}
+
+class WelcomePresenter: ObservableObject {
+    @Published var study: Study
+    @Published var isReady: Bool = true
+    var router: WelcomeEvent?
+    weak var viewController: (UIViewController & WelcomeViewInput)?
+    private let coreData = CoreDataManager.instance
+    private var store = Set<AnyCancellable>()
+    
+    init(router: WelcomeEvent) {
+        self.router = router
+        self.study = WelcomePresenter.createLocalStudy()
+    }
+    
+    // MARK: - Private functions
+    
+    private static func createLocalStudy() -> Study {
+        let sourceLanguage = Language.guessSourceLanguage()
+        let targetLanguage = Language.guessTargetLanguage(from: sourceLanguage)
+        let study = Study(sourceLanguage: sourceLanguage, targerLanguage: targetLanguage)
+        return study
+    }
+    
+    private func saveStudy() {
+        saveToUserDefaults(study: study)
+        saveToCoreData(study: study)
+    }
+    
+    private func saveToUserDefaults(study: Study) {
+        UserDefaultsHelper.nativeLanguage = study.sourceLanguage.code
+        UserDefaultsHelper.targetLanguage = study.targetLanguage.code
+    }
+    
+    private func saveToCoreData(study: Study) {
+        coreData.createStudy(study)
+    }
+    
+    private func checkForReady() {
+        if study.sourceLanguage == study.targetLanguage {
+            self.isReady = false
+        } else {
+            self.isReady = true
+        }
+    }
+}
+
+extension WelcomePresenter: WelcomeViewOutput {
+    
+    // MARK: - Functions
+    
+    func next() {
+        saveStudy()
+        router?.didSendEventClosure?(.complete)
+    }
+    
+    func selectSourceLanguage() {
+        router?.didSendEventClosure?(.source(language: study.sourceLanguage))
+    }
+    
+    func selectTargetLanguage() {
+        router?.didSendEventClosure?(.target(language: study.targetLanguage))
+    }
+    
+    func subscribe() {
+        self.$study
+            .receive(on: RunLoop.main)
+            .sink { [weak self] study in
+                self?.viewController?.configureButtons(type: .source, language: study.sourceLanguage)
+                self?.viewController?.configureButtons(type: .target, language: study.targetLanguage)
+                self?.checkForReady()
+            }
+            .store(in: &store)
+        
+        self.$isReady
+            .receive(on: RunLoop.main)
+            .sink { isRready in
+                self.viewController?.button(isEnable: isRready)
+            }
+            .store(in: &store)
+    }
+    
+    func setLanguage(type: Language.LanguageType, language: Language) {
+        switch type {
+        case .source:
+            study.sourceLanguage = language
+        case .target:
+            study.targetLanguage = language
+        }
+    }
+}

--- a/FlashSpeak/FlashSpeak/Flow/Welcome/Router/WelcomeRouter.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Welcome/Router/WelcomeRouter.swift
@@ -1,0 +1,21 @@
+//
+//  WelcomeRouter.swift
+//  FlashSpeak
+//
+//  Created by Denis Dmitriev on 28.04.2023.
+//
+
+import Foundation
+
+protocol WelcomeEvent {
+    var didSendEventClosure: ((WelcomeRouter.Event) -> Void)? { get set }
+}
+
+struct WelcomeRouter: WelcomeEvent {
+    
+    enum Event {
+        case complete, source(language: Language), target(language: Language)
+    }
+    
+    var didSendEventClosure: ((Event) -> Void)?
+}

--- a/FlashSpeak/FlashSpeak/Flow/Welcome/View/WelcomeView.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Welcome/View/WelcomeView.swift
@@ -1,0 +1,150 @@
+//
+//  WelcomeView.swift
+//  FlashSpeak
+//
+//  Created by Denis Dmitriev on 28.04.2023.
+//
+
+import UIKit
+
+class WelcomeView: UIView {
+    
+    // MARK: - Subviews
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .title1
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .caption1
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let sourcelanguageLabel: UILabel = languageLabel()
+    private let targetlanguageLabel: UILabel = languageLabel()
+    let sourcelanguageButton: UIButton = languageButton()
+    let targetlanguageButton: UIButton = languageButton()
+    
+    let eventButton: UIButton = {
+        let button = UIButton(configuration: UIButton.Configuration.appFilled())
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            titleLabel,
+            subtitleLabel,
+            sourcelanguageLabel,
+            sourcelanguageButton,
+            targetlanguageLabel,
+            targetlanguageButton
+        ])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = Grid.pt16
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        return stackView
+    }()
+    
+    // MARK: - Constraction
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .backgroundLightGray
+        configureTitles()
+        addSubview(stackView)
+        addSubview(eventButton)
+        configureConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    
+    // MARK: - Functions
+    
+    func configureButtons(type: Language.LanguageType, language: Language) {
+        switch type {
+        case .source:
+            configureContentButton(sourcelanguageButton, language)
+        case .target:
+            configureContentButton(targetlanguageButton, language)
+        }
+    }
+    
+    // MARK: - Private functions
+    
+    private static func languageLabel() -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .title3
+        label.textColor = .gray
+        label.textAlignment = .center
+        return label
+    }
+    
+    private static func languageButton() -> UIButton {
+        var configuration = UIButton.Configuration.borderless()
+        configuration.imagePlacement = .bottom
+        configuration.imagePadding = Grid.pt8
+        configuration.buttonSize = .medium
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: Grid.pt8,
+            leading: Grid.pt16,
+            bottom: Grid.pt16,
+            trailing: Grid.pt16
+        )
+        let button = UIButton(configuration: configuration)
+        button.imageView?.layer.cornerRadius = Grid.cr8
+        button.imageView?.layer.masksToBounds = true
+        return button
+    }
+    
+    private func configureTitles() {
+        let title = NSLocalizedString("Добро пожаловать", comment: "Title")
+        let subtitle = NSLocalizedString("Перед началом работы нам нужно знать какой язык вы будете изучать", comment: "Title")
+        let sourcelanguageTitle = NSLocalizedString("Ваш родной язык", comment: "Title")
+        let targetlanguageTitle = NSLocalizedString("Язык изучения", comment: "Title")
+        let eventButtonTitle = NSLocalizedString("Начать", comment: "Button")
+        
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+        sourcelanguageLabel.text = sourcelanguageTitle
+        targetlanguageLabel.text = targetlanguageTitle
+        eventButton.setTitle(eventButtonTitle, for: .normal)
+    }
+    
+    private func configureContentButton(_ button: UIButton, _ source: Language) {
+        let title = source.description
+        let image = UIImage(named: source.code)
+        button.setTitle(title, for: .normal)
+        button.setImage(image, for: .normal)
+    }
+    
+    // MARK: - Constraints
+    
+    private func configureConstraints() {
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Grid.pt16),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Grid.pt16),
+            
+            eventButton.centerXAnchor.constraint(equalTo: centerXAnchor),
+            eventButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Grid.pt96)
+        ])
+    }
+
+}

--- a/FlashSpeak/FlashSpeak/Flow/Welcome/View/WelcomeViewController.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Welcome/View/WelcomeViewController.swift
@@ -1,0 +1,100 @@
+//
+//  WelcomeViewController.swift
+//  FlashSpeak
+//
+//  Created by Denis Dmitriev on 28.04.2023.
+//
+
+import UIKit
+
+class WelcomeViewController: UIViewController {
+    
+    let presenter: WelcomeViewOutput
+    
+    // MARK: - Constraction
+    
+    init(presenter: WelcomeViewOutput) {
+        self.presenter = presenter
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private var welcomeView: WelcomeView {
+        return view as? WelcomeView ?? WelcomeView()
+    }
+    
+    // MARK: - Lifecycle
+    
+    override func loadView() {
+        super.loadView()
+        view = WelcomeView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        presenter.subscribe()
+        configureButtonActions()
+    }
+    
+    // MARK: - Private functions
+    
+    private func configureButtonActions() {
+        welcomeView.eventButton.addTarget(
+            self,
+            action: #selector(didTabEventButton(sender:)),
+            for: .touchUpInside
+        )
+        
+        welcomeView.sourcelanguageButton.addTarget(
+            self,
+            action: #selector(didTabSourceButton(sender:)),
+            for: .touchUpInside
+        )
+        
+        welcomeView.targetlanguageButton.addTarget(
+            self,
+            action: #selector(didTabTargetButton(sender:)),
+            for: .touchUpInside
+        )
+    }
+    
+    // MARK: - Actions
+    
+    @objc func didTabEventButton(sender: UIButton) {
+        didTabDoneButton()
+    }
+    
+    @objc func didTabSourceButton(sender: UIButton) {
+        didTabSourceButton()
+    }
+    
+    @objc func didTabTargetButton(sender: UIButton) {
+        didTabTargetButton()
+    }
+}
+
+extension WelcomeViewController: WelcomeViewInput {
+    
+    func configureButtons(type: Language.LanguageType, language: Language) {
+        welcomeView.configureButtons(type: type, language: language)
+    }
+    
+    func didTabDoneButton() {
+        presenter.next()
+    }
+    
+    func didTabSourceButton() {
+        presenter.selectSourceLanguage()
+    }
+    
+    func didTabTargetButton() {
+        presenter.selectTargetLanguage()
+    }
+    
+    func button(isEnable: Bool) {
+        welcomeView.eventButton.isEnabled = isEnable
+    }
+}

--- a/FlashSpeak/FlashSpeak/Flow/Welcome/WelcomeCoordinator.swift
+++ b/FlashSpeak/FlashSpeak/Flow/Welcome/WelcomeCoordinator.swift
@@ -1,0 +1,80 @@
+//
+//  WelcomeCoordinator.swift
+//  FlashSpeak
+//
+//  Created by Denis Dmitriev on 28.04.2023.
+//
+
+import UIKit
+
+protocol WelcomeCoordinatorProtocol {
+    func showWelcome()
+    func showChangeLanguage(type: Language.LanguageType, language: Language)
+}
+
+class WelcomeCoordinator: Coordinator {
+    weak var finishDelegate: CoordinatorFinishDelegate?
+    
+    var navigationController: UINavigationController
+    
+    var childCoordinators: [Coordinator] = []
+    
+    var type: CoordinatorType { .welcome }
+        
+    required init(_ navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+        
+    func start() {
+        showWelcome()
+    }
+    
+    deinit {
+        print("WelcomeCoordinator deinit")
+    }
+    
+}
+
+extension WelcomeCoordinator: WelcomeCoordinatorProtocol {
+    
+    func showWelcome() {
+        var router = WelcomeRouter()
+        router.didSendEventClosure = { [weak self] event in
+            switch event {
+            case .source(let language):
+                self?.showChangeLanguage(type: .source, language: language)
+            case .target(let language):
+                self?.showChangeLanguage(type: .target, language: language)
+            case .complete:
+                self?.finish()
+            }
+        }
+        let welcomeViewController = WelcomeBuilder.build(router: router)
+//        welcomeViewController.navigationItem.title = "Title"
+        navigationController.pushViewController(welcomeViewController, animated: true)
+    }
+    
+    func showChangeLanguage(type: Language.LanguageType, language: Language) {
+        var router = LanguageRouter()
+        router.didSendEventClosure = { [weak self] event in
+            switch event {
+            case .close:
+                self?.navigationController.dismiss(animated: true)
+            case .change(let language):
+                print(#function, language)
+                self?.navigationController.dismiss(animated: true)
+                self?.updateLanguage(for: type, language: language)
+            }
+        }
+        let languageController = LanguageBuilder.build(router: router, language: language)
+        languageController.modalPresentationStyle = .overFullScreen
+        self.navigationController.present(languageController, animated: true)
+    }
+    
+    private func updateLanguage(for type: Language.LanguageType, language: Language) {
+        guard
+            let welcomeViewController = navigationController.viewControllers.first as? WelcomeViewInput
+        else { return }
+        welcomeViewController.presenter.setLanguage(type: type, language: language)
+    }
+}

--- a/FlashSpeak/FlashSpeak/Model/Models/Language.swift
+++ b/FlashSpeak/FlashSpeak/Model/Models/Language.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 enum Language: Int, CaseIterable {
+    enum LanguageType {
+        case source, target
+    }
+    
     case russian = 0
     case english = 1
     case german = 2
@@ -73,6 +77,29 @@ enum Language: Int, CaseIterable {
             return Self.german
         default:
             return nil
+        }
+    }
+    
+    static func guessSourceLanguage() -> Language {
+        let localLanguageCode = Locale.current.language.languageCode?.identifier ?? "ru"
+        let sourceLanguage = Language.language(by: localLanguageCode) ?? .russian
+        return sourceLanguage
+    }
+    
+    static func guessTargetLanguage(from: Language) -> Language {
+        switch from {
+        case .russian:
+            return .english
+        case .english:
+            return .french
+        case .german:
+            return .english
+        case .french:
+            return .english
+        case .spanish:
+            return .english
+        case .portuguese:
+            return .english
         }
     }
 }


### PR DESCRIPTION
Добавил приветсвенный экран с конструктором Study. На финале по функции next() сохраняется Study пользователя в CoreData и коды языков в UserDefaults Добавил методы guessSourceLanguage() и guessTargetLanguage(from: Language) для первичной идентификации языков для пользователя по вероятности. Добавил логику в AppCoordinator для определения экрана загрузки. Если нет кодов языков в UserDefaults то запускает приветствие, если есть то main flow Добавил подгрузку языка для кнопки changeLanguage
Переписал функцию getLists() - getStudyLists()
Теперь она ищет по кодам из UserDefaults Study и грузит списки слов оттуда Обновил Language flow. Теперь при создании он хочет язык текущий Обновил функцию сохранения списка saveListToCD(_ list: List) для определения Study по UserDefaults Функция generateList(words: [String]) в ListMakerPresenter теперь отправляет реквест с актуальными кодами языков Добавил статичные методы для UserDefaultsHelper target() -> Language? source() -> Language? для удобного определения наличия кодов и получения Добавил метод getStudyObject(source: Language, target: Language) в CoreDataManager для получения Study по паре кодов языков